### PR TITLE
Fix compilation with gcc and clang compiler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ C++ SPMD test project: macro control flow, SSE4.1/AVX1/AVX2/AVX2 FMA support, lo
 
 This a development repo. The implementation is incomplete, it's a lot of brand new code so there are definitely going to be bugs in here, and I am refactoring the code to cut down on the amount of code duplication between the various headers. If you find it useful or interesting, that's wonderful, but please keep in mind this code is actively changing.
 
-IMPORTANT: This code has *ONLY* been compiled with Visual Studio 2019 so far. It should compile with VS 2017 (I tested this earlier, but then I made some simple changes). The original CppSPMD code compiled with clang/gcc, but I've basically rewritten 90% of the code (although I kept its basic structure), so there will need to be fixes/changes for gcc/clang compilation.
+IMPORTANT: This code has *ONLY* been compiled with Visual Studio 2019 so far. It should compile with VS 2017 (I tested this earlier, but then I made some simple changes). The original CppSPMD code compiled with clang/gcc, but I've basically rewritten 90% of the code (although I kept its basic structure), so there will need to be fixes/changes for gcc/clang compilation. At least I've confirmed `test.cpp` compiles fine with gcc 7.5 or later and clang 8 or later.
 
 References:
 -----------

--- a/cppspmd_float4.h
+++ b/cppspmd_float4.h
@@ -63,7 +63,12 @@
 #endif
 
 #ifndef CPPSPMD_FORCE_INLINE
+  #if defined(_MSC_VER)
 	#define CPPSPMD_FORCE_INLINE __forceinline
+  #else
+  // TODO(syoyo): Compiler specific force inline
+	#define CPPSPMD_FORCE_INLINE inline
+  #endif 
 #endif
 
 #undef CPPSPMD
@@ -96,8 +101,12 @@ CPPSPMD_DECL(uint32_t, g_oneu_128[4]) = { 1, 1, 1, 1 };
 
 struct int4;
 
+#if defined(__clang__) || defined(__GNUC__)
+struct CPPSPMD_ALIGN(16) float4
+#else
 CPPSPMD_ALIGN(16)
 struct float4
+#endif
 {
 	float c[4];
 
@@ -108,8 +117,12 @@ struct float4
 	CPPSPMD_FORCE_INLINE float4& operator=(const float4 &a) { c[0] = a.c[0]; c[1] = a.c[1]; c[2] = a.c[2]; c[3] = a.c[3]; return *this; }
 };
 
+#if defined(__clang__) || defined(__GNUC__)
+struct CPPSPMD_ALIGN(16) int4
+#else
 CPPSPMD_ALIGN(16)
 struct int4
+#endif
 {
 	int32_t c[4];
 

--- a/cppspmd_sse.h
+++ b/cppspmd_sse.h
@@ -51,7 +51,11 @@
 #endif
 
 #ifndef CPPSPMD_FORCE_INLINE
+  #if defined(_MSC_VER)
 	#define CPPSPMD_FORCE_INLINE __forceinline
+  #else
+	#define CPPSPMD_FORCE_INLINE inline
+  #endif 
 #endif
 
 #undef CPPSPMD
@@ -225,6 +229,7 @@ struct spmd_kernel
 	CPPSPMD_FORCE_INLINE const float_lref& store_all(const float_lref& dst, const vfloat& src)
 	{
 		_mm_storeu_ps(dst.m_pValue, src.m_value);
+		return dst;
 	}
 
 	CPPSPMD_FORCE_INLINE const float_lref& store_all(const float_lref&& dst, const vfloat& src)

--- a/test.cpp
+++ b/test.cpp
@@ -27,12 +27,16 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#ifdef _WIN32
 #define _CRT_SECURE_NO_WARNINGS 1
+#endif
 
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
 #include <algorithm>
+#include <cstring>
+#include <memory>
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN 1
@@ -219,7 +223,7 @@ inline void writePPM(int *buf, int width, int height, const char *fn) {
     for (int i = 0; i < width*height; ++i) {
         // Map the iteration count to colors by just alternating between
         // two greys.
-        char c = (buf[i] & 0x1) ? 240 : 20;
+        unsigned char c = (buf[i] & 0x1) ? 240 : 20;
         for (int j = 0; j < 3; ++j)
             fputc(c, fp);
     }


### PR DESCRIPTION
This PR fixes compilation with gcc(7.5+) and clang(9.0+) on Linux
At least I've confirmed `test.cpp` compiles fine.
