### PR TITLE
Build out fp32 functionality a bit more

### DIFF
--- a/cppspmd_avx1.h
+++ b/cppspmd_avx1.h
@@ -1412,6 +1412,9 @@ CPPSPMD_FORCE_INLINE vfloat fnms(const vfloat& a, const vfloat& b, const vfloat&
 	return vfloat{ _mm256_sub_ps(_mm256_sub_ps(_mm256_xor_ps(a.m_value, a.m_value), _mm256_mul_ps(a.m_value, b.m_value)), c.m_value) };
 }
 
+// control is an 8-bit immediate value containing 4 2-bit indices which shuffles the floats in each 128-bit lane.
+#define VFLOAT_LANE_SHUFFLE_PS(a, control) vfloat(_mm256_permute_ps((a).m_value, control))
+
 CPPSPMD_FORCE_INLINE vfloat lerp(const vfloat &x, const vfloat &y, const vfloat &s) { return vfma(y - x, s, x); }
 
 CPPSPMD_FORCE_INLINE lint operator+(int a, const lint& b) { __m128i k = _mm_set1_epi32(a); return lint{ _mm_add_epi32(k, b.m_value_l), _mm_add_epi32(k, b.m_value_h) }; }

--- a/cppspmd_avx512.h
+++ b/cppspmd_avx512.h
@@ -1078,6 +1078,9 @@ CPPSPMD_FORCE_INLINE vfloat vfnms(const vfloat& a, const vfloat& b, const vfloat
 	return vfloat{ _mm512_fnmsub_ps(a.m_value, b.m_value, c.m_value) };
 }
 
+// control is an 8-bit immediate value containing 4 2-bit indices which shuffles the floats in each 128-bit lane.
+#define VFLOAT_LANE_SHUFFLE_PS(a, control) vfloat(_mm512_permute_ps((a).m_value, control))
+
 CPPSPMD_FORCE_INLINE vfloat lerp(const vfloat& x, const vfloat& y, const vfloat& s) { return vfma(y - x, s, x); }
 
 CPPSPMD_FORCE_INLINE lint operator+(int a, const lint& b) { return lint{ _mm512_add_epi32(_mm512_set1_epi32(a), b.m_value) }; }

--- a/cppspmd_float4.h
+++ b/cppspmd_float4.h
@@ -380,6 +380,17 @@ CPPSPMD_FORCE_INLINE int movemask_epi8(const int4& a)
 	return mask;
 }
 
+CPPSPMD_FORCE_INLINE int4 lane_shuffle_ps_float4(const float4& a, int control)
+{
+	assert(control >= 0 && control < 256);
+	float4 result;
+	result.c[0] = a.c[control & 3];
+	result.c[1] = a.c[(control >> 2) & 3];
+	result.c[2] = a.c[(control >> 4) & 3];
+	result.c[3] = a.c[(control >> 6) & 3];
+	return result;
+}
+
 CPPSPMD_FORCE_INLINE int4 lane_shuffle_epi32_int4(const int4& a, int control)
 {
 	assert(control >= 0 && control < 256);
@@ -1739,6 +1750,9 @@ CPPSPMD_FORCE_INLINE vfloat vfnms(const vfloat& a, const vfloat& b, const vfloat
 {
 return vfloat{ fnms_float4(a.m_value, b.m_value, c.m_value) };
 }
+
+// control is an 8-bit immediate value containing 4 2-bit indices which shuffles the floats in each 128-bit lane.
+#define VFLOAT_LANE_SHUFFLE_PS(a, control) vfloat(lane_shuffle_ps_float4((a).m_value, control))
 
 CPPSPMD_FORCE_INLINE vfloat lerp(const vfloat &x, const vfloat &y, const vfloat &s) { return vfma(y - x, s, x); }
 

--- a/cppspmd_math.h
+++ b/cppspmd_math.h
@@ -666,28 +666,28 @@ CPPSPMD_FORCE_INLINE vint cmple_epi16(const vint &a, const vint &b)
 	return cmpge_epi16(b, a);
 }
 
-void spmd_kernel::print_vint(vint v) 
+CPPSPMD_FORCE_INLINE void spmd_kernel::print_vint(vint v)
 { 
 	for (uint32_t i = 0; i < PROGRAM_COUNT; i++) 
 		printf("%i ", extract(v, i)); 
 	printf("\n"); 
 }
 
-void spmd_kernel::print_vbool(vbool v) 
+CPPSPMD_FORCE_INLINE void spmd_kernel::print_vbool(vbool v)
 { 
 	for (uint32_t i = 0; i < PROGRAM_COUNT; i++) 
 		printf("%i ", extract(v, i) ? 1 : 0); 
 	printf("\n"); 
 }
 	
-void spmd_kernel::print_vint_hex(vint v) 
+CPPSPMD_FORCE_INLINE void spmd_kernel::print_vint_hex(vint v)
 { 
 	for (uint32_t i = 0; i < PROGRAM_COUNT; i++) 
 		printf("0x%X ", extract(v, i)); 
 	printf("\n"); 
 }
 
-void spmd_kernel::print_active_lanes(const char *pPrefix) 
+CPPSPMD_FORCE_INLINE void spmd_kernel::print_active_lanes(const char *pPrefix)
 { 
 	CPPSPMD_DECL(int, flags[PROGRAM_COUNT]);
 	memset(flags, 0, sizeof(flags));
@@ -704,7 +704,7 @@ void spmd_kernel::print_active_lanes(const char *pPrefix)
 	printf("\n");
 }
 	
-void spmd_kernel::print_vfloat(vfloat v) 
+CPPSPMD_FORCE_INLINE void spmd_kernel::print_vfloat(vfloat v)
 { 
 	for (uint32_t i = 0; i < PROGRAM_COUNT; i++) 
 		printf("%f ", extract(v, i)); 

--- a/cppspmd_sse.h
+++ b/cppspmd_sse.h
@@ -1515,6 +1515,9 @@ CPPSPMD_FORCE_INLINE vfloat vfnms(const vfloat& a, const vfloat& b, const vfloat
 	return vfloat{ _mm_sub_ps(_mm_sub_ps(_mm_xor_ps(a.m_value, a.m_value), _mm_mul_ps(a.m_value, b.m_value)), c.m_value) };
 }
 
+// control is an 8-bit immediate value containing 4 2-bit indices which shuffles the floats in each 128-bit lane.
+#define VFLOAT_LANE_SHUFFLE_PS(a, control) vfloat(_mm_shuffle_ps((a).m_value, (a).m_value, control))
+
 CPPSPMD_FORCE_INLINE vfloat lerp(const vfloat &x, const vfloat &y, const vfloat &s) { return vfma(y - x, s, x); }
 
 CPPSPMD_FORCE_INLINE lint operator+(int a, const lint& b) { return lint{ _mm_add_epi32(_mm_set1_epi32(a), b.m_value) }; }


### PR DESCRIPTION
Add utility functions (floatbits, intbits, shuffle, bit twiddling, rsqrt_fast)
Add float3 / float4 helpers.
Change print functions to inline to get around multiple includes.

Apologies for not including full implementations for all targets!